### PR TITLE
fix: remove osshurl for maven publishing

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -37,7 +37,6 @@ java:
     shortName: MIT
     url: https://mit-license.org/
   maxMethodParams: 4
-  ossrhURL: https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/
   outputModelSuffix: output
   projectName: ding
   templateVersion: v2


### PR DESCRIPTION
- `osshurl` is not needed for maven publishing of type "Sonatype Central" : https://www.speakeasy.com/docs/publish-sdks#java-maven-sonatype-central-portal-recommended and is likely causing publishign to attempt legacy sonatype java publishing first

- After merging please regenerate and publish