### PR TITLE
fix: Update sdk_publish.yaml to include OSSRH Username

### DIFF
--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -20,5 +20,6 @@ jobs:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       java_gpg_passphrase: ${{ secrets.JAVA_GPG_PASSPHRASE }}
       java_gpg_secret_key: ${{ secrets.JAVA_GPG_SECRET_KEY }}
+      ossrh_username: ${{ secrets.OSSRH_USERNAME }}
       ossrh_password: ${{ secrets.OSSRH_PASSWORD }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}


### PR DESCRIPTION
- Following guide here: https://www.speakeasy.com/docs/publish-sdks#java-maven-sonatype-central-portal-recommended 